### PR TITLE
Add tooling to allow for running more tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
             - name: build
               uses: MitchellThompkins/cocoOS_github_action@v0.0.3
               with:
-                command: make build.a9
+                command: make build.all
 
             - name: test
               uses: MitchellThompkins/cocoOS_github_action@v0.0.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,4 @@ jobs:
             - name: test
               uses: MitchellThompkins/cocoOS_github_action@v0.0.3
               with:
-                command: make qemu-run.a9 check-trace
+                command: make test check-trace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
 
-#add_compile_options(-std=c++11 -Wall -Werror -v)
-#add_compile_options(-std=c++11 -v)
-#add_compile_options(-H)
-
 project(test
     LANGUAGES CXX C ASM
 )

--- a/debug.mk
+++ b/debug.mk
@@ -1,5 +1,20 @@
-.PHONY: qemu-debug.%
-qemu-debug.%:
+.PHONY: %.qemu-run
+%.qemu-run:
+	qemu-system-arm \
+		-nographic \
+		--no-reboot \
+		-serial stdio \
+		-monitor none \
+		-machine xilinx-zynq-a9 \
+		-cpu cortex-a9 \
+		-m 12M \
+		--semihosting \
+		-semihosting-config enable=on,target=native \
+		-kernel build/$*
+
+# For example: make a9/test_os_task0.elf.qemu-gdb
+.PHONY: %.qemu-gdb
+%.qemu-gdb:
 	qemu-system-arm \
 		-nographic \
 		--no-reboot \
@@ -11,23 +26,9 @@ qemu-debug.%:
 		-d guest_errors\
 		--semihosting \
 		-semihosting-config enable=on,target=native \
-		-kernel build/$*/test_os_task0.elf
+		-kernel build/$*
 
-.PHONY: qemu-run.%
-qemu-run.%:
-	qemu-system-arm \
-		-nographic \
-		--no-reboot \
-		-serial stdio \
-		-monitor none \
-		-machine xilinx-zynq-a9 \
-		-cpu cortex-a9 \
-		-m 12M \
-		--semihosting \
-		-semihosting-config enable=on,target=native \
-		-kernel build/$*/test_os_task0.elf
-
-.PHONY: gdb-debug.%
-gdb-debug.%:
-	gdb build/$*/test_os_task0.elf -ix .gdbinit
+.PHONY: %.gdb
+%.gdb:
+	gdb build/$* -ix .gdbinit
 

--- a/debug.mk
+++ b/debug.mk
@@ -1,0 +1,33 @@
+.PHONY: qemu-debug.%
+qemu-debug.%:
+	qemu-system-arm \
+		-nographic \
+		--no-reboot \
+		-gdb tcp::1234 \
+		-S \
+		-machine xilinx-zynq-a9 \
+		-cpu cortex-a9 \
+		-m 12M \
+		-d guest_errors\
+		--semihosting \
+		-semihosting-config enable=on,target=native \
+		-kernel build/$*/test_os_task0.elf
+
+.PHONY: qemu-run.%
+qemu-run.%:
+	qemu-system-arm \
+		-nographic \
+		--no-reboot \
+		-serial stdio \
+		-monitor none \
+		-machine xilinx-zynq-a9 \
+		-cpu cortex-a9 \
+		-m 12M \
+		--semihosting \
+		-semihosting-config enable=on,target=native \
+		-kernel build/$*/test_os_task0.elf
+
+.PHONY: gdb-debug.%
+gdb-debug.%:
+	gdb build/$*/test_os_task0.elf -ix .gdbinit
+

--- a/makefile
+++ b/makefile
@@ -37,39 +37,7 @@ container.start:
 ### Utility ###########################
 #######################################
 
-		#-serial mon:stdio
-.PHONY: qemu-debug.%
-qemu-debug.%:
-	qemu-system-arm \
-		-nographic \
-		--no-reboot \
-		-gdb tcp::1234 \
-		-S \
-		-machine xilinx-zynq-a9 \
-		-cpu cortex-a9 \
-		-m 12M \
-		-d guest_errors\
-		--semihosting \
-		-semihosting-config enable=on,target=native \
-		-kernel build/$*/test_os_task0.elf
-
-.PHONY: qemu-run.%
-qemu-run.%:
-	qemu-system-arm \
-		-nographic \
-		--no-reboot \
-		-serial stdio \
-		-monitor none \
-		-machine xilinx-zynq-a9 \
-		-cpu cortex-a9 \
-		-m 12M \
-		--semihosting \
-		-semihosting-config enable=on,target=native \
-		-kernel build/$*/test_os_task0.elf
-
-.PHONY: gdb-debug.%
-gdb-debug.%:
-	gdb build/$*/test_os_task0.elf -ix .gdbinit
+include debug.mk
 
 #TODO(@mthompkins): Use poetry to manage deps
 .PHONY: check-trace

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ UID=$(shell id -u)
 GID=$(shell id -g)
 
 #######################################
-### Building Software #################
+### build #############################
 #######################################
 
 .PHONY: build.all
@@ -20,8 +20,17 @@ build.%: build.cmake.%
 build.graph:
 	cmake --graphviz=test.dot . -DPLATFORM=CORTEX_A9
 
+
 #######################################
-### Container #########################
+### test #########################
+#######################################
+.PHONY: test
+test: 
+	python3 scripts/test.py -t tests/tests.json 
+
+
+#######################################
+### container #########################
 #######################################
 
 .PHONY: container.pull
@@ -34,20 +43,24 @@ container.start:
 
 
 #######################################
-### Utility ###########################
+### utility ###########################
 #######################################
-
-include debug.mk
 
 #TODO(@mthompkins): Use poetry to manage deps
 .PHONY: check-trace
 check-trace:
 	python3 -m pip install click termcolor 
 	python3 scripts/trace_reqs.py --req documents/requirements.csv --test cpputest_TestOsTask.xml
-
+	
 .PHONY: clean
 clean:
 	rm -rf build/
+
+#######################################
+### debug ###########################
+#######################################
+include debug.mk
+
 
 # All the Makefiles read themselves get matched if a target exists for them, so
 # they will get matched by a Match anything target %:. This target is here

--- a/os/os_utils/include/os_defines.h
+++ b/os/os_utils/include/os_defines.h
@@ -3,60 +3,59 @@
 
 #include "user_os_config.h"
 
-/** @file os_defines.h cocoOS user configuration
-          Macros can be defined in this file or as compiler flags e.g. -DN_TASKS=2 -DN_EVENTS=3...
-*/
-
+#ifndef N_TASKS
+#error N_TASKS must be defined with #define
+#endif
 #ifdef __cplusplus
-extern "C" {
+static_assert(N_TASKS>=0 && N_TASKS<255, "Maximum number of tasks is 254");
+#else
+_Static_assert(N_TASKS>=0 && N_TASKS<255, "Maximum number of tasks is 254");
 #endif
 
-/** Max number of used tasks
-* @remarks Must be defined. @n Allowed range: 0-254. Value must not be exceeded */
-//#ifndef N_TASKS
-//#define N_TASKS 1
-//#endif
-_Static_assert (N_TASKS>=0 && N_TASKS<255, "Maximum number of tasks is 254");
+
+#ifndef N_QUEUES
+#error N_QUEUES must be defined with #define
+#endif
+#ifdef __cplusplus
+static_assert(N_QUEUES >= 0 && N_QUEUES < 255, "Maximum number of queues is 254");
+#else
+_Static_assert(N_QUEUES >= 0 && N_QUEUES < 255, "Maximum number of queues is 254");
+#endif
 
 
-
-/** Max number of used message queues
-* @remarks Must be defined. @n Allowed range: 0-254. Value must not be exceeded */
-//#ifndef N_QUEUES
-//#define N_QUEUES 0
-//#endif
-_Static_assert (N_QUEUES >= 0 && N_QUEUES < 255, "Maximum number of queues is 254");
-
-
-/** Max number of used semaphores
-* @remarks Must be defined. @n Allowed range: 0-254. Value must not be exceeded */
-//#ifndef N_SEMAPHORES
-//#define N_SEMAPHORES 0
-//#endif
-_Static_assert (N_SEMAPHORES >=0 && N_SEMAPHORES < 255, "Maximum number of queues is 254");
+#ifndef N_SEMAPHORES
+#error N_SEMAPHORES must be defined with #define
+#endif
+#ifdef __cplusplus
+static_assert(N_SEMAPHORES >=0 && N_SEMAPHORES < 255, "Maximum number of queues is 254");
+#else
+_Static_assert(N_SEMAPHORES >=0 && N_SEMAPHORES < 255, "Maximum number of queues is 254");
+#endif
 
 
-/** Max number of used events
-* @remarks Must be defined. @n Allowed range: 0-254. Value must not be exceeded */
-//#ifndef N_EVENTS
-//#define N_EVENTS 0
-//#endif
-_Static_assert (N_EVENTS >=0 && N_EVENTS < 255, "Maximum number of events is 254");
+#ifndef N_QUEUES
+#error N_EVENTS must be defined with #define
+#endif
+#ifdef __cplusplus
+static_assert(N_EVENTS >=0 && N_EVENTS < 255, "Maximum number of events is 254");
+#else
+_Static_assert(N_EVENTS >=0 && N_EVENTS < 255, "Maximum number of events is 254");
+#endif
 
 
-/** Round Robin scheduling
-* @remarks If defined, tasks will be scheduled ignoring the priorities */
-//#ifndef ROUND_ROBIN
-//#define ROUND_ROBIN 0
-//#endif
-_Static_assert (ROUND_ROBIN == 0 || ROUND_ROBIN == 1, "ROUND_ROBIN must be 0 or 1");
+#ifndef N_QUEUES
+#error ROUND_ROBIN must be defined as 0 or 1
+#endif
+#ifdef __cplusplus
+static_assert(ROUND_ROBIN == 0 || ROUND_ROBIN == 1, "ROUND_ROBIN must be 0 or 1");
+#else
+_Static_assert(ROUND_ROBIN == 0 || ROUND_ROBIN == 1, "ROUND_ROBIN must be 0 or 1");
+#endif
 
 
-/** Memory size
- * @remarks Should be set to the size of address pointer */
-//#ifndef Mem_t
-//#define Mem_t uint32_t
-//#endif
+#ifndef Mem_t
+#error A type (like uint32_t for example) must be defined for Mem_t
+#endif
 
 #define NO_MSG_ID   0xff
 #define ISR_TID     0xfe
@@ -67,9 +66,5 @@ _Static_assert (ROUND_ROBIN == 0 || ROUND_ROBIN == 1, "ROUND_ROBIN must be 0 or 
 
 /* Total number of events needed */
 #define N_TOTAL_EVENTS        ( N_EVENTS + N_QUEUES )
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,57 @@
+import argparse
+import json
+import subprocess
+import sys
+
+def cli(tests):
+
+    s = []
+
+    s.append("qemu-system-arm")
+    s.append("-nographic")
+    s.append("--no-reboot")
+    s.append("-serial")
+    s.append("stdio")
+    s.append("-monitor")
+    s.append("none")
+    s.append("-machine")
+    s.append("xilinx-zynq-a9")
+    s.append("-cpu")
+    s.append("cortex-a9")
+    s.append("-m")
+    s.append("12M")
+    s.append("--semihosting")
+    s.append("-semihosting-config")
+    s.append("enable=on,target=native")
+    s.append("-kernel")
+    s.append("build/a9/test_os_task0.elf")
+
+    print(' '.join(s))
+
+    result = subprocess.run(s)
+    sys.exit(result)
+
+def parse_tests(test_file:str):
+
+    with open(test_file, 'r') as f:
+        # returns JSON object as
+        # a dictionary
+        data = json.load(f)
+
+        # Iterating through the json
+        # list
+        for i in data['tests']:
+            print(i)
+
+def get_args():
+    p = argparse.ArgumentParser("run tests")
+    p.add_argument('--tests_json', '-t', required=True)
+
+    return p.parse_args()
+
+
+if __name__ == '__main__':
+    a = get_args()
+    tests = parse_tests(a.tests_json)
+    cli(tests)
+

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -35,9 +35,8 @@ class Test:
         results = []
         for exe in self.exes:
             s = self._assemble_command(exe)
-            print(s)
-            print()
-            result = subprocess.run(s)
+            print(f"\n{' '.join(s)}\n")
+            results.append( subprocess.run(s).returncode)
 
         return results
 
@@ -81,8 +80,17 @@ def parse_tests(test_def_json:str):
 
 
 def cli(tests):
+    results = []
+
     for t in tests:
-        t.run_tests()
+        results.append( t.run_tests() )
+
+    for r in results:
+        for test_result in r:
+            if test_result != 0:
+                sys.exit(test_result)
+
+    sys.exit(0)
 
 
 def get_args():

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_subdirectory(platforms)
 add_subdirectory(os_task)
 
+#TODO(@mthompkins): Compile with -Wall
+#add_compile_options(-std=c++14 -Wall -Werror -v)
+add_compile_options(-std=c++14)
+
 include(FetchContent)
 FetchContent_Declare(
     CppUTest

--- a/tests/platforms/arm/cortex-a9/src/crt1.c
+++ b/tests/platforms/arm/cortex-a9/src/crt1.c
@@ -8,8 +8,8 @@
 extern "C" {
 #endif
 
-//extern __attribute__((long_call)) int main(int argc, char *argv[]);
-extern __attribute__((long_call)) int main();
+// main() isn't name mangled by c++
+extern __attribute__((long_call)) int main(void);
 
 extern uint32_t __bss_start;
 extern uint32_t __bss_end;

--- a/tests/platforms/arm/cortex-a9/src/crt1.c
+++ b/tests/platforms/arm/cortex-a9/src/crt1.c
@@ -8,7 +8,8 @@
 extern "C" {
 #endif
 
-extern __attribute__((long_call)) int main(int argc, char *argv[]);
+//extern __attribute__((long_call)) int main(int argc, char *argv[]);
+extern __attribute__((long_call)) int main();
 
 extern uint32_t __bss_start;
 extern uint32_t __bss_end;
@@ -68,17 +69,7 @@ void _start(void)
     // Do constructor init
     ctors();
 
-    // TODO(@mthompkins): Make this modular, and additionally running with
-    // ojunit and v seems to disable the output :(
-    // Jump to main()
-    int argc = 3;
-    char *argv[argc];
-    int status = 1;
-
-    argv[0] = "test";
-    argv[1] = "-ojunit";
-    argv[2] = "-v";
-    status = main(argc, argv);
+    int status = main();
 
     dtors();
 

--- a/tests/src/main.cpp
+++ b/tests/src/main.cpp
@@ -2,7 +2,7 @@
 
 #include "CppUTest/CommandLineTestRunner.h"
 
-int main()
+int main(void)
 {
     // TODO(@mthompkins): Consider taking these in at the commandline, although
     // this does give us control over what arguments are passed.

--- a/tests/src/main.cpp
+++ b/tests/src/main.cpp
@@ -2,8 +2,18 @@
 
 #include "CppUTest/CommandLineTestRunner.h"
 
-int main(int argc, char *argv[])
+int main()
 {
+    // TODO(@mthompkins): Consider taking these in at the commandline, although
+    // this does give us control over what arguments are passed.
+    int argc = 3;
+    const char *argv[argc] =
+    {
+        "test_name",
+        "-ojunit",
+        "-v",
+    };
+
     int result = CommandLineTestRunner::RunAllTests(argc, argv);
 
     return result;

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -1,0 +1,12 @@
+{
+    "tests":[
+        {
+            "type": "host",
+            "name": "test_os_task0"
+        },
+        {
+            "type": "target",
+            "name": "test_os_task0"
+        }
+    ]
+}

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -2,11 +2,14 @@
     "tests":[
         {
             "type": "host",
-            "name": "test_os_task0"
+            "dir": "build/x86_64"
         },
         {
-            "type": "target",
-            "name": "test_os_task0"
+            "type": "qemu-system-arm",
+            "dir": "build/a9",
+            "machine": "xilinx-zynq-a9",
+            "cpu": "cortex-a9",
+            "memory": "12M"
         }
     ]
 }

--- a/tests/user_config/user_os_config.h
+++ b/tests/user_config/user_os_config.h
@@ -1,11 +1,11 @@
 #ifndef USER_OS_CONFIG_H
 #define USER_OS_CONFIG_H
 
-#define N_TASKS      10
-#define N_QUEUES     0
+#define N_TASKS 10
+#define N_QUEUES 0
 #define N_SEMAPHORES 10
-#define N_EVENTS     0
-#define ROUND_ROBIN  0
-#define Mem_t        uint32_t
+#define N_EVENTS 0
+#define ROUND_ROBIN 0
+#define Mem_t  uint32_t
 
 #endif


### PR DESCRIPTION
# Changes
* Started building tests for both `x86_64` and `a9` (which required changing main's definition a bit)
* Added a python tool to gather and run all tests
* Specified c++ version
* Broke debug makefile functionality to separate makefile for eventual removal