### PR TITLE
Tweak scheduling macros and improve data encapsulation

### DIFF
--- a/os/os_event/include/os_event.h
+++ b/os/os_event/include/os_event.h
@@ -16,7 +16,7 @@ extern "C" {
 #define EVENT_OFS3   12000
 
 #define OS_WAIT_SINGLE_EVENT(x,timeout, cb) do {\
-                                os_wait_event(running_tid,x,1,timeout, cb);\
+                                os_wait_event(os_get_running_tid(),x,1,timeout, cb);\
                                 OS_SCHEDULE(EVENT_OFS1);\
                                } while (0)
 
@@ -29,7 +29,7 @@ extern "C" {
 
 #define OS_SIGNAL_EVENT(event)  do {\
                                 os_signal_event(event);\
-                                os_event_set_signaling_tid( event, running_tid );\
+                                os_event_set_signaling_tid( event, os_get_running_tid() );\
                                 OS_SCHEDULE(EVENT_OFS3);\
                                 } while (0)
 
@@ -40,7 +40,7 @@ extern "C" {
                                     } while (0)
 
 
-#define OS_GET_TASK_TIMEOUT_VALUE()  os_task_timeout_get(running_tid)
+#define OS_GET_TASK_TIMEOUT_VALUE()  os_task_timeout_get(os_get_running_tid())
 
 
 #ifdef N_TOTAL_EVENTS

--- a/os/os_event/src/os_event.c
+++ b/os/os_event/src/os_event.c
@@ -4,10 +4,11 @@
 #include "os_event.h"
 
 /* Event type */
-typedef struct {
-		uint8_t id;
-		uint8_t signaledByTid;
-		} Event_t;
+typedef struct
+{
+    uint8_t id;
+    uint8_t signaledByTid;
+} Event_t;
 
 
 
@@ -28,7 +29,7 @@ void os_event_init(void) {
 
 /*********************************************************************************/
 /*  Evt_t event_create()                                              *//**
-*   
+*
 *   Creates an event.
 *
 *   @return Returns an event.
@@ -39,19 +40,19 @@ void os_event_init(void) {
 *   Evt_t myEvent;
 *   myEvent = event_create();
 *   @endcode
-*       
-*		 */
+*
+* */
 /*********************************************************************************/
 Evt_t event_create( void ) {
     #if( N_TOTAL_EVENTS > 0 )
-	os_assert( nEvents < N_TOTAL_EVENTS );
+    os_assert( nEvents < N_TOTAL_EVENTS );
 
     eventList[ nEvents ].id = nEvents;
     eventList[ nEvents ].signaledByTid = NO_TID;
-	
-	++nEvents;
 
-	return nEvents - 1;
+    ++nEvents;
+
+    return nEvents - 1;
     #else
     return 0;
     #endif
@@ -60,9 +61,9 @@ Evt_t event_create( void ) {
 
 /*********************************************************************************/
 /*  uint8_t event_signaling_taskId_get( ev )                                              *//**
-*   
+*
 *   Gets the Task Id of the task that signaled the event.
-*   
+*
 *   @param ev event
 *   @return Id of task that signaled the event.
 *   @return NO_TID if a timeout occurred before the event was signaled.
@@ -78,12 +79,12 @@ Evt_t event_create( void ) {
 *     ...
 *   }
 *   @endcode
-*       
-*		 */
+*
+* */
 /*********************************************************************************/
 uint8_t event_signaling_taskId_get( Evt_t ev ) {
 #if( N_TOTAL_EVENTS > 0 )
-	return eventList[ ev ].signaledByTid;
+    return eventList[ ev ].signaledByTid;
 #else
     return 0;
 #endif
@@ -108,11 +109,11 @@ uint8_t event_signaling_taskId_get( Evt_t ev ) {
 *   }
 *   @endcode
 *
-*		 */
+* */
 /*********************************************************************************/
 Evt_t event_last_signaled_get(void) {
 #if( N_TOTAL_EVENTS > 0 )
-	return lastSignaledEvent;
+    return lastSignaledEvent;
 #else
     return NO_EVENT;
 #endif
@@ -142,25 +143,25 @@ void os_signal_event( Evt_t ev ) {
 
 void os_event_set_signaling_tid( Evt_t ev, uint8_t tid ) {
 #if( N_TOTAL_EVENTS > 0 )
-	eventList[ ev ].signaledByTid = tid;
+    eventList[ ev ].signaledByTid = tid;
 #endif
 }
 
 
 void os_wait_multiple( uint8_t waitAll, ...) {
 #if( N_TOTAL_EVENTS > 0 )
-	int event;
-	va_list args;
-	va_start( args, waitAll );
-	os_task_clear_wait_queue( running_tid );
-	event = va_arg( args, int );
+    int event;
+    va_list args;
+    va_start( args, waitAll );
+    os_task_clear_wait_queue( os_get_running_tid() );
+    event = va_arg( args, int );
 
-	do {
-		os_task_wait_event( running_tid, (Evt_t)event, !waitAll,0 );
-		event = va_arg( args, int );
-	} while ( event != NO_EVENT );
+    do {
+        os_task_wait_event( os_get_running_tid(), (Evt_t)event, !waitAll,0 );
+        event = va_arg( args, int );
+    } while ( event != NO_EVENT );
 
-	va_end(args);
+    va_end(args);
 #endif
 }
 

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -39,7 +39,7 @@ extern "C" {
 
 
 #define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){goto loop;} else{goto cont;} } while(0)
-#define task_wait_macro(x) do{ task_wait_test(x); goto loop; cont: } while(0)
+#define task_wait_macro(x) do{ task_wait_test(x); goto loop; cont:; } while(0)
 #define task_close_macro() do{ terminate: task_close_test(); loop: return; } while(0)
 
 //TODO(@tthompkins): Consider making these static uint8_t private to

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -38,7 +38,7 @@ extern "C" {
                                  } while ( 0 )
 
 
-#define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){goto loop;} else{goto cont} } while(0)
+#define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){goto loop;} else{goto cont;} } while(0)
 #define task_wait_macro(x) do{ task_wait_test(x); goto loop; cont: } while(0)
 #define task_close_macro() do{ terminate: task_close_test(); loop: return; } while(0)
 

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -38,9 +38,10 @@ extern "C" {
                                  } while ( 0 )
 
 
-#define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){return;} else{task_open_test();} } while(0)
-#define task_wait_macro(x) do{ task_wait_test(x); return; } while(0)
-#define task_close_macro() do{ task_close_test(); } while(0)
+#define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){goto loop;} else{task_open_test();} } while(0)
+#define task_wait_macro(x) do{ task_wait_test(x); goto loop; } while(0)
+//#define task_close_macro() do{ task_close_test(); } while(0)
+#define task_close_macro() do{ loop: return; exit: task_close_test(); } while(0)
 
 //TODO(@tthompkins): Consider making these static uint8_t private to
 //os_kernel.c

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -41,7 +41,7 @@ extern "C" {
 #define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){goto loop;} else{task_open_test();} } while(0)
 #define task_wait_macro(x) do{ task_wait_test(x); goto loop; } while(0)
 //#define task_close_macro() do{ task_close_test(); } while(0)
-#define task_close_macro() do{ loop: return; exit: task_close_test(); } while(0)
+#define task_close_macro() do{ terminate: task_close_test(); loop: return; } while(0)
 
 //TODO(@tthompkins): Consider making these static uint8_t private to
 //os_kernel.c

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -38,7 +38,7 @@ extern "C" {
                                  } while ( 0 )
 
 
-#define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){goto loop;} else{goto cont;} } while(0)
+#define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){goto loop;} else if{task_is_killed( os_get_running_tid_test() )}  else{goto cont;} } while(0)
 #define task_wait_macro(x) do{ task_wait_test(x); goto loop; cont:; } while(0)
 #define task_close_macro() do{ terminate: task_close_test(); loop: return; } while(0)
 

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -17,34 +17,24 @@ extern "C" {
 #define NO_SEM   255
 
 //TODO(@mthompkins): Figure out if we need all these macros
-#define OS_BEGIN  uint16_t os_task_state = task_internal_state_get(running_tid); switch ( os_task_state ) { case 0:
+//
+#define OS_BEGIN     switch ( task_internal_state_get( os_get_running_tid() ) ) { case 0:
 
-#define OS_END    os_task_kill(running_tid);\
-                  running_tid = NO_TID;\
-                  return;}
+#define OS_END       os_task_kill( os_get_running_tid() );\
+                     os_free_tid();\
+                     return; }
 
-
-#define OS_SCHEDULE(ofs)    os_task_internal_state_set(running_tid, __LINE__+ofs);\
-                            running_tid = NO_TID;\
-                            return;\
-                            case (__LINE__+ofs):
-
-
+#define OS_SCHEDULE  os_task_internal_state_set( os_get_running_tid(), __LINE__ );\
+                     os_free_tid();\
+                     return;\
+                     case (__LINE__):
 
 
-#define OS_WAIT_TICKS(x,y)	do {\
-                                os_task_wait_time_set( running_tid, y, x );\
-                                OS_SCHEDULE(0);\
-                                 } while ( 0 )
-
-
-#define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){goto loop;} else if{task_is_killed( os_get_running_tid_test() )}  else{goto cont;} } while(0)
-#define task_wait_macro(x) do{ task_wait_test(x); goto loop; cont:; } while(0)
-#define task_close_macro() do{ terminate: task_close_test(); loop: return; } while(0)
+#define OS_WAIT_TICKS(time,id)  do { os_task_wait_time_set( os_get_running_tid(), id, time );\
+                                OS_SCHEDULE; } while (0)
 
 //TODO(@tthompkins): Consider making these static uint8_t private to
 //os_kernel.c
-extern uint8_t running_tid;
 extern uint8_t last_running_task;
 extern uint8_t running;
 

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -38,7 +38,7 @@ extern "C" {
                                  } while ( 0 )
 
 
-#define task_open_macro() do{ if( !task_should_run_test( os_get_running_tid_test() ) ){return}; else{task_open_test();} } while(0)
+#define task_open_macro() do{ if( !task_should_run_test( os_get_running_tid_test() ) ){return;} else{task_open_test();} } while(0)
 #define task_wait_macro(x) do{ task_wait_test(x); return; } while(0)
 #define task_close_macro(x) do{ task_close_test(); } while(0)
 

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -38,9 +38,9 @@ extern "C" {
                                  } while ( 0 )
 
 
-#define task_open_macro() do{ if( !task_should_run_test( os_get_running_tid_test() ) ){return;} else{task_open_test();} } while(0)
+#define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){return;} else{task_open_test();} } while(0)
 #define task_wait_macro(x) do{ task_wait_test(x); return; } while(0)
-#define task_close_macro(x) do{ task_close_test(); } while(0)
+#define task_close_macro() do{ task_close_test(); } while(0)
 
 //TODO(@tthompkins): Consider making these static uint8_t private to
 //os_kernel.c

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -16,8 +16,6 @@ extern "C" {
 #define NO_QUEUE 255
 #define NO_SEM   255
 
-//TODO(@mthompkins): Figure out if we need all these macros
-//
 #define OS_BEGIN     switch ( task_internal_state_get( os_get_running_tid() ) ) { case 0:
 
 #define OS_END       os_task_kill( os_get_running_tid() );\
@@ -32,12 +30,6 @@ extern "C" {
 
 #define OS_WAIT_TICKS(time,id)  do { os_task_wait_time_set( os_get_running_tid(), id, time );\
                                 OS_SCHEDULE; } while (0)
-
-//TODO(@tthompkins): Consider making these static uint8_t private to
-//os_kernel.c
-extern uint8_t last_running_task;
-extern uint8_t running;
-
 
 //TODO(@tthompkins): Consider removing this
 #ifdef UNIT_TEST

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -38,9 +38,8 @@ extern "C" {
                                  } while ( 0 )
 
 
-#define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){goto loop;} else{task_open_test();} } while(0)
-#define task_wait_macro(x) do{ task_wait_test(x); goto loop; } while(0)
-//#define task_close_macro() do{ task_close_test(); } while(0)
+#define task_open_macro()  do{ if( !task_should_run_test( os_get_running_tid_test() ) ){goto loop;} else{goto cont} } while(0)
+#define task_wait_macro(x) do{ task_wait_test(x); goto loop; cont: } while(0)
 #define task_close_macro() do{ terminate: task_close_test(); loop: return; } while(0)
 
 //TODO(@tthompkins): Consider making these static uint8_t private to

--- a/os/os_kernel/include/cocoos.h
+++ b/os/os_kernel/include/cocoos.h
@@ -38,6 +38,9 @@ extern "C" {
                                  } while ( 0 )
 
 
+#define task_open_macro() do{ if( !task_should_run_test( os_get_running_tid_test() ) ){return}; else{task_open_test();} } while(0)
+#define task_wait_macro(x) do{ task_wait_test(x); return; } while(0)
+#define task_close_macro(x) do{ task_close_test(); } while(0)
 
 //TODO(@tthompkins): Consider making these static uint8_t private to
 //os_kernel.c

--- a/os/os_kernel/include/os_kernel.h
+++ b/os/os_kernel/include/os_kernel.h
@@ -858,7 +858,9 @@ void os_sub_tick( uint8_t id );
 
 void os_sub_nTick( uint8_t id, uint32_t nTicks );
 
-uint8_t os_get_running_tid(void);
+uint16_t os_get_running_tid(void);
+
+void os_free_tid(void);
 
 //TODO(@mthompkins): I think this is better placed in os_task.h
 void task_kill( uint8_t tid );
@@ -866,11 +868,6 @@ void task_kill( uint8_t tid );
 Evt_t event_create( void );
 uint8_t event_signaling_taskId_get( Evt_t ev );
 void os_cbkSleep( void );
-
-
-void task_open_test( void );
-void task_close_test( void );
-void task_wait_test( const uint16_t time );
 
 #ifdef __cplusplus
 }

--- a/os/os_kernel/include/os_kernel.h
+++ b/os/os_kernel/include/os_kernel.h
@@ -17,7 +17,7 @@ extern "C" {
 /** @file os_kernel.h cocoOS API header file*/
 /*********************************************************************************/
 /*  task_open()                                                 *//**
-*   
+*
 *   Macro for definition of task beginning.
 *
 *   @remarks \b Usage: Should be placed at the beginning of the task procedure @n
@@ -26,7 +26,7 @@ extern "C" {
 
 static void myTask(void) {
  static uint8_t i;
- task_open();	
+ task_open();
   ...
   task_wait( 10 );
   ...

--- a/os/os_kernel/include/os_kernel.h
+++ b/os/os_kernel/include/os_kernel.h
@@ -867,6 +867,11 @@ Evt_t event_create( void );
 uint8_t event_signaling_taskId_get( Evt_t ev );
 void os_cbkSleep( void );
 
+
+void task_open_test( void );
+void task_close_test( void );
+void task_wait_test( void );
+
 #ifdef __cplusplus
 }
 #endif

--- a/os/os_kernel/include/os_kernel.h
+++ b/os/os_kernel/include/os_kernel.h
@@ -870,7 +870,7 @@ void os_cbkSleep( void );
 
 void task_open_test( void );
 void task_close_test( void );
-void task_wait_test( void );
+void task_wait_test( const uint16_t time );
 
 #ifdef __cplusplus
 }

--- a/os/os_kernel/mocks/src/mock_os_kernel.c
+++ b/os/os_kernel/mocks/src/mock_os_kernel.c
@@ -42,9 +42,15 @@ uint8_t os_running(void)
     return running;
 }
 
-uint8_t os_get_running_tid(void)
+uint16_t os_get_running_tid(void)
 {
+    mock_c()->actualCall("os_get_running_tid");
     return running_tid;
+}
+
+void os_free_tid(void)
+{
+    mock_c()->actualCall("os_free_tid");
 }
 
 Evt_t event_create( void )

--- a/os/os_kernel/mocks/src/mock_os_kernel.c
+++ b/os/os_kernel/mocks/src/mock_os_kernel.c
@@ -8,14 +8,12 @@
 #include "os_sem.h"
 #include "os_task.h"
 
-uint8_t running;
-uint8_t running_tid;
-uint8_t last_running_task;
+static uint8_t running;
+static uint8_t running_tid;
 
 void os_init(void)
 {
     running_tid = NO_TID;
-    last_running_task = NO_TID;
     running = 0;
 
     mock_c()->actualCall("os_init");

--- a/os/os_kernel/src/os_kernel.c
+++ b/os/os_kernel/src/os_kernel.c
@@ -247,7 +247,7 @@ void task_close_test(void)
 
 void task_wait_test(void)
 {
-    os_task_internal_state_set(99);
+    os_task_internal_state_set(running_tid_test, 99);
     running_tid_test = NO_TID;
 }
 

--- a/os/os_kernel/src/os_kernel.c
+++ b/os/os_kernel/src/os_kernel.c
@@ -14,6 +14,8 @@ uint8_t running_tid;
 uint8_t last_running_task;
 uint8_t running;
 
+static uint8_t running_tid_test = 0;
+
 /*********************************************************************************/
 /*  void os_init()                                              *//**
 *   
@@ -34,6 +36,7 @@ uint8_t running;
 /*********************************************************************************/
 void os_init( void ) {
     running_tid = NO_TID;
+    running_tid_test = NO_TID;
     last_running_task = NO_TID;
     running = 0;
     os_sem_init();
@@ -66,6 +69,26 @@ static void os_schedule( void ) {
 }
 
 
+static void os_schedule_test( void ) {
+
+    running_tid_test = NO_TID;
+
+#if (ROUND_ROBIN)
+    /* Find next ready task */
+    running_tid_test = os_task_next_ready_task();
+#else
+    /* Find the highest prio task ready to run */
+    running_tid_test = os_task_highest_prio_ready_task();   
+#endif
+    if ( running_tid != NO_TID )
+    {
+        os_task_run_test(running_tid_test);
+    }
+    else
+    {
+        os_cbkSleep();
+    }
+}
 
 
 /*********************************************************************************/
@@ -109,7 +132,8 @@ void os_start_locking( void (*lock)(void), void (*unlock)(void) )
     for(;;)
     {
         lock();
-        os_schedule();
+        //os_schedule();
+        os_schedule_test();
         unlock();
     }
 }
@@ -204,6 +228,29 @@ uint8_t os_running( void ) {
 uint8_t os_get_running_tid(void) {
     return running_tid;
 }
+
+uint8_t os_get_running_tid_test(void)
+{
+    return running_tid_test;
+}
+
+void task_open_test(void)
+{
+    //running_tid_test = task_internal_state_get(running_tid_test);
+}
+
+void task_close_test(void)
+{
+    os_task_kill(running_tid_test);
+    running_tid_test = NO_TID;
+}
+
+void task_wait_test(void)
+{
+    os_task_internal_state_set(99);
+    running_tid_test = NO_TID;
+}
+
 
 //TODO(mthompkins): I don't see where unit tests so I reccomend removal of this
 //#ifdef UNIT_TEST

--- a/os/os_kernel/src/os_kernel.c
+++ b/os/os_kernel/src/os_kernel.c
@@ -80,7 +80,7 @@ static void os_schedule_test( void ) {
     /* Find the highest prio task ready to run */
     running_tid_test = os_task_highest_prio_ready_task();   
 #endif
-    if ( running_tid != NO_TID )
+    if ( running_tid_test != NO_TID )
     {
         os_task_run_test(running_tid_test);
     }

--- a/os/os_kernel/src/os_kernel.c
+++ b/os/os_kernel/src/os_kernel.c
@@ -247,8 +247,8 @@ void task_close_test(void)
 
 void task_wait_test( const uint16_t time )
 {
-    os_task_wait_time_set( running_tid_test, 0, time );
     os_task_internal_state_set(running_tid_test, 99);
+    os_task_wait_time_set( running_tid_test, 0, time );
     running_tid_test = NO_TID;
 }
 

--- a/os/os_kernel/src/os_kernel.c
+++ b/os/os_kernel/src/os_kernel.c
@@ -10,13 +10,11 @@
 
 static void os_schedule( void );
 
-uint8_t last_running_task;
-uint8_t running;
-
+static uint8_t running = 0;
 static uint16_t running_tid = NO_TID;
 
 /*********************************************************************************/
-/*  void os_init()                                              *//**
+/*  void os_init()
 *
 *   Initializes the scheduler.
 *   @return None.
@@ -33,9 +31,9 @@ static uint16_t running_tid = NO_TID;
 *
 * */
 /*********************************************************************************/
-void os_init( void ) {
+void os_init( void )
+{
     running_tid = NO_TID;
-    last_running_task = NO_TID;
     running = 0;
     os_sem_init();
     os_event_init();
@@ -194,13 +192,15 @@ void os_sub_tick( uint8_t id )
 void os_sub_nTick( uint8_t id, uint32_t nTicks )
 {
     /* Sub clock tick */
-    if ( id != 0 ) {
+    if ( id != 0 )
+    {
         task_tick( id, nTicks );
     }
 }
 
 
-uint8_t os_running( void ) {
+uint8_t os_running( void )
+{
     return running;
 }
 
@@ -210,6 +210,7 @@ uint16_t os_get_running_tid(void)
     return running_tid;
 }
 
+//TODO(mthompkins): make this inline to speed up macros
 void os_free_tid(void)
 {
     running_tid = NO_TID;

--- a/os/os_kernel/src/os_kernel.c
+++ b/os/os_kernel/src/os_kernel.c
@@ -245,8 +245,9 @@ void task_close_test(void)
     running_tid_test = NO_TID;
 }
 
-void task_wait_test(void)
+void task_wait_test( const uint16_t time )
 {
+    os_task_wait_time_set( running_tid_test, 0, time );
     os_task_internal_state_set(running_tid_test, 99);
     running_tid_test = NO_TID;
 }

--- a/os/os_msgqueue/include/os_msgqueue.h
+++ b/os/os_msgqueue/include/os_msgqueue.h
@@ -37,23 +37,24 @@ enum {
 
 
 
-
+// TODO(mtchompkins) I highly suspect alot of this can be wrapped into a
+// function that the macro calls
 #define OS_MSG_Q_POST(task_id, msg, delay, period, async )     do {\
                                                                 uint8_t os_posted;\
                                                                 MsgQ_t queue;\
                                                                 queue = os_msgQ_find(task_id);\
-                                                                os_task_set_wait_queue(running_tid, queue);\
+                                                                os_task_set_wait_queue(os_get_running_tid(), queue);\
                                                                 Evt_t event;\
                                                                 event = os_msgQ_event_get( queue );\
-                                                                os_task_set_change_event(running_tid, event);\
+                                                                os_task_set_change_event(os_get_running_tid(), event);\
                                                                 do {\
                                                                     os_posted = os_msg_post( (Msg_t*)&msg, os_msgQ_find(task_id), delay, period );\
                                                                     if ( os_posted == MSG_QUEUE_FULL ){\
                                                                         if ( async == 0 ) {\
-                                                                            os_task_set_msg_result(running_tid, os_posted);\
+                                                                            os_task_set_msg_result(os_get_running_tid(), os_posted);\
                                                                             event_wait(event);\
-                                                                            os_posted = os_task_get_msg_result(running_tid);\
-                                                                            event = os_task_get_change_event(running_tid);\
+                                                                            os_posted = os_task_get_msg_result(os_get_running_tid());\
+                                                                            event = os_task_get_change_event(os_get_running_tid());\
                                                                         }\
                                                                         else {\
                                                                             os_posted = MSG_QUEUE_UNDEF;\
@@ -61,8 +62,8 @@ enum {
                                                                     }\
                                                                 } while ( os_posted == MSG_QUEUE_FULL );\
                                                                 if ( MSG_QUEUE_POSTED == os_posted ) {\
-                                                                	os_signal_event(event);\
-                                                                	os_event_set_signaling_tid( event, running_tid );\
+                                                                    os_signal_event(event);\
+                                                                    os_event_set_signaling_tid( event, os_get_running_tid() );\
                                                                 }\
                                                             } while(0)
 
@@ -72,21 +73,21 @@ enum {
                                                     uint8_t os_received;\
                                                     MsgQ_t queue;\
                                                     queue = os_msgQ_find(task_id);\
-                                                    os_task_set_wait_queue(running_tid, queue);\
+                                                    os_task_set_wait_queue(os_get_running_tid(), queue);\
                                                     Evt_t event;\
                                                     event = os_msgQ_event_get(queue);\
-                                                    os_task_set_change_event(running_tid, event);\
+                                                    os_task_set_change_event(os_get_running_tid(), event);\
                                                     do {\
                                                         os_received = os_msg_receive((Msg_t*)pMsg, os_msgQ_find(task_id));\
                                                         if ( os_received == MSG_QUEUE_EMPTY ){\
                                                             if ( async == 0 ) {\
-       	                                                        os_task_set_msg_result(running_tid, os_received);\
+       	                                                        os_task_set_msg_result(os_get_running_tid(), os_received);\
                                                                 if (cb) {\
                                                                  ((void (*)())cb)();\
                                                                 }\
                                                                 event_wait(event);\
-                                                                os_received = os_task_get_msg_result(running_tid);\
-                                                                event = os_task_get_change_event(running_tid);\
+                                                                os_received = os_task_get_msg_result(os_get_running_tid());\
+                                                                event = os_task_get_change_event(os_get_running_tid());\
                                                             }\
                                                             else {\
                                                                 ((Msg_t*)pMsg)->signal = NO_MSG_ID;\
@@ -96,7 +97,7 @@ enum {
                                                     } while ( os_received == MSG_QUEUE_EMPTY );\
                                                     if ( MSG_QUEUE_RECEIVED == os_received) {\
                                                     	os_signal_event(event);\
-                                                    	os_event_set_signaling_tid(event, running_tid );\
+                                                    	os_event_set_signaling_tid(event, os_get_running_tid() );\
 													}\
                                                 } while(0)
 

--- a/os/os_sem/include/os_sem.h
+++ b/os/os_sem/include/os_sem.h
@@ -18,7 +18,7 @@ extern "C" {
                                         os_sem_decrement( sem );\
                                     }\
                                     else{\
-                                        os_task_wait_sem_set( running_tid, sem );\
+                                        os_task_wait_sem_set( os_get_running_tid(), sem );\
                                         OS_SCHEDULE(SEM_OFS1);\
                                     }\
                                 } while (0)

--- a/os/os_task/include/os_task.h
+++ b/os/os_task/include/os_task.h
@@ -115,6 +115,8 @@ TaskState_t task_state_get( uint8_t tid );
 
 bool task_should_run_test(const uint16_t id);
 
+bool task_is_killed(const uint16_t id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/os/os_task/include/os_task.h
+++ b/os/os_task/include/os_task.h
@@ -113,7 +113,7 @@ void *task_get_data( void );
 
 TaskState_t task_state_get( uint8_t tid );
 
-bool task_should_run_test(void);
+bool task_should_run_test(const uint16_t id);
 
 #ifdef __cplusplus
 }

--- a/os/os_task/include/os_task.h
+++ b/os/os_task/include/os_task.h
@@ -35,7 +35,7 @@ typedef enum {
 
 #define OS_SUSPEND_TASK( id ) do {\
                                    os_task_suspend( id );\
-                                   if ( id == running_tid ) {\
+                                   if ( id == os_get_running_tid() ) {\
                                        OS_SCHEDULE(TASK_OFS1);\
                                    }\
                                 } while (0)
@@ -45,7 +45,7 @@ typedef enum {
 
 #define OS_RESUME_TASK( id ) do {\
                                  os_task_resume( id );\
-                                 if ( id == running_tid ) {\
+                                 if ( id == os_get_running_tid() ) {\
                                      OS_SCHEDULE(TASK_OFS2);\
                                  }\
                              } while (0)

--- a/os/os_task/include/os_task.h
+++ b/os/os_task/include/os_task.h
@@ -4,6 +4,7 @@
 /** @file os_task.h Task header file*/
 
 #include "stdint.h"
+#include "stdbool.h"
 
 #include "os_defines.h"
 #include "os_event.h"
@@ -80,6 +81,8 @@ void os_task_signal_event( Evt_t eventId );
 
 void os_task_run( void );
 
+void os_task_run_test( const uint8_t id );
+
 uint16_t task_internal_state_get( uint8_t tid );
 
 void os_task_internal_state_set( uint8_t tid, uint16_t state );
@@ -109,6 +112,8 @@ uint8_t task_create( taskproctype taskproc, void *data, uint8_t prio, Msg_t* msg
 void *task_get_data( void );
 
 TaskState_t task_state_get( uint8_t tid );
+
+bool task_should_run_test(void);
 
 #ifdef __cplusplus
 }

--- a/os/os_task/src/os_task.c
+++ b/os/os_task/src/os_task.c
@@ -43,8 +43,12 @@ static void task_killed_set( uint8_t tid );
 static tcb task_list[ N_TASKS ];
 static uint8_t nTasks = 0;
 
+static uint16_t last_running_task = 0;
+
 void os_task_init( void )
 {
+    last_running_task = 0;
+
     uint8_t i;
     uint8_t j;
     nTasks = 0;
@@ -298,12 +302,15 @@ uint8_t os_task_next_ready_task( void )
     uint8_t found;
     uint8_t nChecked;
 
-    if ( NO_TID == last_running_task ) {
+    if ( NO_TID == last_running_task )
+    {
         index = 0;
     }
-    else {
+    else
+    {
         index = last_running_task + 1;
-        if ( index >= nTasks ) {
+        if ( index >= nTasks )
+        {
             index = 0;
         }
     }
@@ -312,7 +319,8 @@ uint8_t os_task_next_ready_task( void )
     nChecked = 0;
 
     do {
-        if ( READY == task_list[ index ].state ) {
+        if ( READY == task_list[ index ].state )
+        {
             last_running_task = index;
             found = 1;
             break;
@@ -324,7 +332,8 @@ uint8_t os_task_next_ready_task( void )
         }
     } while ( ++nChecked != nTasks );
 
-    if ( !found ) {
+    if ( !found )
+    {
         last_running_task = NO_TID;
     }
 
@@ -460,7 +469,8 @@ void os_task_resume( uint8_t tid )
 
 
 //TODO(@mthompkins): this is a simple wrapper, consider removal
-void os_task_kill( uint8_t tid ) {
+void os_task_kill( uint8_t tid )
+{
     os_assert( tid < nTasks );
     task_killed_set( tid );
 
@@ -749,6 +759,10 @@ bool task_is_killed(const uint16_t id)
     return state==KILLED;
 }
 
+void task_set_no_running_task(void)
+{
+    last_running_task = NO_TID;
+}
 
 #ifdef __cplusplus
 }

--- a/os/os_task/src/os_task.c
+++ b/os/os_task/src/os_task.c
@@ -640,6 +640,10 @@ void os_task_run( void ) {
     task_list[ running_tid ].taskproc();
 }
 
+void os_task_run_test( const uint8_t id ) {
+    os_assert( id < nTasks );
+    task_list[ id ].taskproc();
+}
 
 uint16_t task_internal_state_get( uint8_t tid )
 {
@@ -728,6 +732,12 @@ static void task_waiting_event_timeout_set( tcb *task ) {
 
 static void task_killed_set( uint8_t tid ) {
     task_list[ tid ].state = KILLED;
+}
+
+bool task_should_run_test(const uint16_t id)
+{
+    const uint8_t state = task_internal_state_get(id);
+    return state==0 || state==99;
 }
 
 #ifdef __cplusplus

--- a/os/os_task/src/os_task.c
+++ b/os/os_task/src/os_task.c
@@ -257,7 +257,8 @@ int main() {
 /*********************************************************************************/
 void *task_get_data()
 {
-  return task_list[ running_tid ].data;
+    const uint16_t tid = os_get_running_tid();
+    return task_list[ tid ].data;
 }
 
 /* Finds the task with highest prio that are ready to run - used for prio based scheduling */
@@ -635,9 +636,11 @@ void os_task_signal_event( Evt_t eventId ) {
 
 
 /* Runs the next task ready for execution. Assumes running_tid has been assigned */
-void os_task_run( void ) {
-    os_assert( running_tid < nTasks );
-    task_list[ running_tid ].taskproc();
+void os_task_run( void )
+{
+    const uint16_t tid = os_get_running_tid();
+    os_assert( tid < nTasks );
+    task_list[ tid ].taskproc();
 }
 
 void os_task_run_test( const uint8_t id ) {

--- a/os/os_task/src/os_task.c
+++ b/os/os_task/src/os_task.c
@@ -740,6 +740,13 @@ bool task_should_run_test(const uint16_t id)
     return state==0 || state==99;
 }
 
+bool task_should_run_test(const uint16_t id)
+{
+    const uint8_t state = task_internal_state_get(id);
+    return state==KILLED;
+}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/os/os_task/src/os_task.c
+++ b/os/os_task/src/os_task.c
@@ -740,7 +740,7 @@ bool task_should_run_test(const uint16_t id)
     return state==0 || state==99;
 }
 
-bool task_should_run_test(const uint16_t id)
+bool task_is_killed(const uint16_t id)
 {
     const uint8_t state = task_internal_state_get(id);
     return state==KILLED;

--- a/temp_notes.md
+++ b/temp_notes.md
@@ -72,9 +72,18 @@
   * The macros create variables with names, so if you were unlikely and chose
     the same variable name, it would fail to compile but in a really weird way.
 
-  * There's a bug which is for the _first_ run, if
+  * There's a bug which is for the _first_ run in a `for(;;)` definition, if
     you have any code _after_ a `task_wait` it will never get called (b/c you
     start in case 0) and jump to return as soon as you set the wait state.
+
+  * I'd like to turn this into something MISRA compliant, and the heavy marcro
+    usage violates
+    > Misra rule 19.7 : A function should be used in preference to a function-like macro
+    I think removing or at least removing the heavy macro usage will allow for
+    something more robust, safer, and test-able. All of this text subsitution
+    is a strong code smell, even though I do think it's really clever. I think
+    there's some control flow implementation that will probably achieve
+    something similar
 
 
 ```dot

--- a/temp_notes.md
+++ b/temp_notes.md
@@ -121,93 +121,10 @@
     }
     ```
 
-    * After a ton of heart-ache, I've figured out that this is just Duff's
-      Device for approximating re-entrant code whilst abusing the C macro. As
-      such, I'm not going to change the program flow, though I am going to
-      change a few things.
+    * After a ton of heart-ache, I've figured out that this is  Duff's Device
+      for approximating re-entrant code whilst abusing the C macro. As such,
+      I'm not going to change the program flow, though I am going to change a
+      few things.
 
-
-```dot
-digraph "test" {
-node [
-  fontsize = "12"
-];
-subgraph clusterLegend {
-  label = "Legend";
-  color = black;
-  edge [ style = invis ];
-  legendNode0 [ label = "Executable", shape = egg ];
-  legendNode1 [ label = "Static Library", shape = octagon ];
-  legendNode2 [ label = "Shared Library", shape = doubleoctagon ];
-  legendNode3 [ label = "Module Library", shape = tripleoctagon ];
-  legendNode4 [ label = "Interface Library", shape = pentagon ];
-  legendNode5 [ label = "Object Library", shape = hexagon ];
-  legendNode6 [ label = "Unknown Library", shape = septagon ];
-  legendNode7 [ label = "Custom Target", shape = box ];
-  legendNode0 -> legendNode1 [ style = solid ];
-  legendNode0 -> legendNode2 [ style = solid ];
-  legendNode0 -> legendNode3;
-  legendNode1 -> legendNode4 [ label = "Interface", style = dashed ];
-  legendNode2 -> legendNode5 [ label = "Private", style = dotted ];
-  legendNode3 -> legendNode6 [ style = solid ];
-  legendNode0 -> legendNode7;
-}
-    "node0" [ label = "CppUTest\n(CppUTest::CppUTest)", shape = octagon ];
-    "node1" [ label = "-pthread", shape = septagon ];
-    "node0" -> "node1" [ style = dotted ] // CppUTest -> -pthread
-    "node2" [ label = "CppUTestExt\n(CppUTest::CppUTestExt)", shape = octagon ];
-    "node2" -> "node0"  // CppUTestExt -> CppUTest
-    "node3" [ label = "mocks", shape = octagon ];
-    "node3" -> "node0" [ style = dotted ] // mocks -> CppUTest
-    "node3" -> "node2" [ style = dotted ] // mocks -> CppUTestExt
-    "node4" [ label = "os_event_impl", shape = octagon ];
-    "node5" [ label = "os_event_intf", shape = pentagon ];
-    "node4" -> "node5" [ style = dotted ] // os_event_impl -> os_event_intf
-    "node6" [ label = "os_kernel_intf", shape = pentagon ];
-    "node7" [ label = "os_msgqueue_intf", shape = pentagon ];
-    "node7" -> "node5" [ style = dashed ] // os_msgqueue_intf -> os_event_intf
-    "node8" [ label = "os_utils_intf", shape = pentagon ];
-    "node7" -> "node8" [ style = dashed ] // os_msgqueue_intf -> os_utils_intf
-    "node6" -> "node7" [ style = dashed ] // os_kernel_intf -> os_msgqueue_intf
-    "node9" [ label = "os_sem_intf", shape = pentagon ];
-    "node6" -> "node9" [ style = dashed ] // os_kernel_intf -> os_sem_intf
-    "node10" [ label = "os_task_intf", shape = pentagon ];
-    "node10" -> "node5" [ style = dashed ] // os_task_intf -> os_event_intf
-    "node10" -> "node7" [ style = dashed ] // os_task_intf -> os_msgqueue_intf
-    "node10" -> "node9" [ style = dashed ] // os_task_intf -> os_sem_intf
-    "node10" -> "node8" [ style = dashed ] // os_task_intf -> os_utils_intf
-    "node6" -> "node10" [ style = dashed ] // os_kernel_intf -> os_task_intf
-    "node4" -> "node6" [ style = dotted ] // os_event_impl -> os_kernel_intf
-    "node11" [ label = "os_kernel_impl", shape = octagon ];
-    "node11" -> "node5"  // os_kernel_impl -> os_event_intf
-    "node11" -> "node6"  // os_kernel_impl -> os_kernel_intf
-    "node11" -> "node10"  // os_kernel_impl -> os_task_intf
-    "node11" -> "node8"  // os_kernel_impl -> os_utils_intf
-    "node12" [ label = "os_msgqueue_impl", shape = octagon ];
-    "node12" -> "node6"  // os_msgqueue_impl -> os_kernel_intf
-    "node12" -> "node7"  // os_msgqueue_impl -> os_msgqueue_intf
-    "node13" [ label = "os_sem_impl", shape = octagon ];
-    "node13" -> "node9"  // os_sem_impl -> os_sem_intf
-    "node14" [ label = "os_task_impl", shape = octagon ];
-    "node14" -> "node6"  // os_task_impl -> os_kernel_intf
-    "node14" -> "node9"  // os_task_impl -> os_sem_intf
-    "node14" -> "node10"  // os_task_impl -> os_task_intf
-    "node14" -> "node8"  // os_task_impl -> os_utils_intf
-    "node15" [ label = "os_utils_impl", shape = octagon ];
-    "node15" -> "node6"  // os_utils_impl -> os_kernel_intf
-    "node15" -> "node8"  // os_utils_impl -> os_utils_intf
-    "node16" [ label = "platform", shape = octagon ];
-    "node16" -> "node6" [ style = dotted ] // platform -> os_kernel_intf
-    "node17" [ label = "test", shape = egg ];
-    "node17" -> "node0" [ style = dotted ] // test -> CppUTest
-    "node17" -> "node2" [ style = dotted ] // test -> CppUTestExt
-    "node17" -> "node4" [ style = dotted ] // test -> os_event_impl
-    "node17" -> "node11" [ style = dotted ] // test -> os_kernel_impl
-    "node17" -> "node12" [ style = dotted ] // test -> os_msgqueue_impl
-    "node17" -> "node13" [ style = dotted ] // test -> os_sem_impl
-    "node17" -> "node14" [ style = dotted ] // test -> os_task_impl
-    "node17" -> "node15" [ style = dotted ] // test -> os_utils_impl
-    "node17" -> "node16" [ style = dotted ] // test -> platform
-    "node17" -> "node17"  // test -> test
-}
-```
+    * __LINE__+ofs isn't offering much in the macros, it just makes things a
+      bit more confusing I'd argue, so I removed them for now

--- a/temp_notes.md
+++ b/temp_notes.md
@@ -72,9 +72,10 @@
   * The macros create variables with names, so if you were unlikely and chose
     the same variable name, it would fail to compile but in a really weird way.
 
-  * There's a bug which is for the _first_ run in a `for(;;)` definition, if
+  * ~~There's a bug which is for the _first_ run in a `for(;;)` definition, if
     you have any code _after_ a `task_wait` it will never get called (b/c you
-    start in case 0) and jump to return as soon as you set the wait state.
+    start in case 0) and jump to return as soon as you set the wait state.~~
+    This isn't the case, it works as expected.
 
   * I'd like to turn this into something MISRA compliant, and the heavy marcro
     usage violates
@@ -95,13 +96,17 @@
     an actual case used by the user in a switch statement, that's a very
     difficult bug to track down.
 
-    Even if the compiler doesn't complain, the below will print 0, b/c x is
+    ~~Even if the compiler doesn't complain, the below will print 0, b/c x is
     valid and scoped to the switch statement (which is fine), but let's say we
     re-enter on case 2, previously having entered case 1...you're going to have
     a bad time b/c x is going to be wrong, b/c the previous value of x was
     pop'd off the stack...and yet here you are using it. This can probably be
     fixed by adding an explicit variable store/restore function that the user
-    opts to use to store variables between re-entry.
+    opts to use to store variables between re-entry.~~ This is a known
+    limitation of the implementation. The solutionis to decalre all of your
+    variables static, or, pass the task a pointer to data that you're going to
+    want to access.
+
     ```
        switch(2)
     {


### PR DESCRIPTION
# Changes
* This makes a few changes to the scheduling macros, in particular it removes the global variables and scopes them to their implementation files. It wasn't until looking at the macros in depth that I realized this achieves something approaching re-entry using a [modified version of Duff's Device](https://www.chiark.greenend.org.uk/~sgtatham/coroutines.html).
* Adds formatting changes